### PR TITLE
Make MenuPage.nav writeable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/MenuChanger/LocalOverrides.targets

--- a/MenuChanger/MenuChanger.csproj
+++ b/MenuChanger/MenuChanger.csproj
@@ -11,7 +11,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>1701;1702;CS1591;IDE0018</NoWarn>
+    <HollowKnightRefs>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
   </PropertyGroup>
+  <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')"/>
   <ItemGroup>
     <Using Remove="System.Net.Http" />
     <Using Remove="System.Threading" />
@@ -23,46 +25,46 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MMHOOK_PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Target Name="CopyMod" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\$(TargetName)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml" DestinationFolder="$(HollowKnightRefs)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/MenuChanger/MenuPage.cs
+++ b/MenuChanger/MenuPage.cs
@@ -13,7 +13,7 @@ namespace MenuChanger
         public readonly GameObject self;
         public readonly RectTransform rt;
         public readonly CanvasGroup cg;
-        public readonly MenuPageNavigation nav;
+        public MenuPageNavigation nav;
 
         /// <summary>
         /// The MenuPage which the GoBack method and the back button directs to. Can be modified after creation. If null, defaults to going back to the profile menu.
@@ -136,6 +136,22 @@ namespace MenuChanger
         public void AddToNavigationControl(ISelectable selectable)
         {
             nav.Add(selectable);
+        }
+
+        /// <summary>
+        /// Replaces the page's navigation control with a new one, migrates all the selectable elements
+        /// corrently controlled by the page's navigation into the new one, and recursively resets navigation
+        /// for the page.
+        /// </summary>
+        /// <param name="newNav">The new navigation to use</param>
+        public void ReplaceNavigation(MenuPageNavigation newNav)
+        {
+            foreach (ISelectable s in nav.Selectables)
+            {
+                newNav.Add(s);
+            }
+            nav = newNav;
+            ResetNavigation();
         }
 
         /// <summary>

--- a/MenuChanger/MenuPage.cs
+++ b/MenuChanger/MenuPage.cs
@@ -146,7 +146,7 @@ namespace MenuChanger
         /// <param name="newNav">The new navigation to use</param>
         public void ReplaceNavigation(MenuPageNavigation newNav)
         {
-            foreach (ISelectable s in nav.Selectables)
+            foreach (ISelectable s in nav.Items)
             {
                 newNav.Add(s);
             }

--- a/MenuChanger/MenuPageNavigation.cs
+++ b/MenuChanger/MenuPageNavigation.cs
@@ -12,7 +12,7 @@
 
         public MenuPage Page { get; }
 
-        public abstract IReadOnlyCollection<ISelectable> Selectables { get; }
+        public abstract IReadOnlyCollection<ISelectable> Items { get; }
 
         /// <summary>
         /// Adds the ISelectable to navigation control.

--- a/MenuChanger/MenuPageNavigation.cs
+++ b/MenuChanger/MenuPageNavigation.cs
@@ -12,6 +12,8 @@
 
         public MenuPage Page { get; }
 
+        public abstract IReadOnlyCollection<ISelectable> Selectables { get; }
+
         /// <summary>
         /// Adds the ISelectable to navigation control.
         /// </summary>

--- a/MenuChanger/NavigationTypes/SimpleHorizontalNavigation.cs
+++ b/MenuChanger/NavigationTypes/SimpleHorizontalNavigation.cs
@@ -1,13 +1,12 @@
 ﻿using MenuChanger.Extensions;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine.UI;
 
 namespace MenuChanger.NavigationTypes
 {
     public class SimpleHorizontalNavigation : MenuPageNavigation
     {
-        public List<ISelectable> Selectables = new();
+        public List<ISelectable> selectables = new();
+
+        public override IReadOnlyCollection<ISelectable> Selectables => selectables.AsReadOnly();
 
         public SimpleHorizontalNavigation(MenuPage page) : base(page)
         {
@@ -15,9 +14,9 @@ namespace MenuChanger.NavigationTypes
 
         public override void SelectDefault()
         {
-            if (Selectables.Count > 0)
+            if (selectables.Count > 0)
             {
-                Selectable s = Selectables[0].GetSelectable(Neighbor.Up);
+                Selectable s = selectables[0].GetSelectable(Neighbor.Up);
                 if (s)
                 {
                     s.Select();
@@ -25,19 +24,22 @@ namespace MenuChanger.NavigationTypes
                 }
             }
 
-            if (Page.backButton != null && Page.backButton.Button) Page.backButton.Button.Select();
+            if (Page.backButton != null && Page.backButton.Button)
+            {
+                Page.backButton.Button.Select();
+            }
         }
 
         public override void Add(ISelectable selectable)
         {
             selectable.SetNeighbor(Neighbor.Down, Page.backButton);
             selectable.SetNeighbor(Neighbor.Up, Page.backButton);
-            if (Selectables.Any())
+            if (selectables.Any())
             {
-                selectable.SetNeighbor(Neighbor.Left, Selectables[Selectables.Count - 1]);
-                Selectables[Selectables.Count - 1].SetNeighbor(Neighbor.Right, selectable);
-                selectable.SetNeighbor(Neighbor.Right, Selectables[0]);
-                Selectables[0].SetNeighbor(Neighbor.Left, selectable);
+                selectable.SetNeighbor(Neighbor.Left, selectables[selectables.Count - 1]);
+                selectables[selectables.Count - 1].SetNeighbor(Neighbor.Right, selectable);
+                selectable.SetNeighbor(Neighbor.Right, selectables[0]);
+                selectables[0].SetNeighbor(Neighbor.Left, selectable);
             }
             else
             {
@@ -47,19 +49,19 @@ namespace MenuChanger.NavigationTypes
                 selectable.SetNeighbor(Neighbor.Right, selectable);
             }
 
-            Selectables.Add(selectable);
+            selectables.Add(selectable);
         }
 
         public override void Remove(ISelectable selectable)
         {
-            int i = Selectables.IndexOf(selectable);
+            int i = selectables.IndexOf(selectable);
             if (i >= 0)
             {
-                Selectables.RemoveAt(i);
-                if (Selectables.Any())
+                selectables.RemoveAt(i);
+                if (selectables.Any())
                 {
-                    ISelectable previous = Selectables[i > 0 ? i - 1 : Selectables.Count - 1];
-                    ISelectable next = Selectables[i < Selectables.Count ? i : 0];
+                    ISelectable previous = selectables[i > 0 ? i - 1 : selectables.Count - 1];
+                    ISelectable next = selectables[i < selectables.Count ? i : 0];
                     previous.SetNeighbor(Neighbor.Right, next);
                     next.SetNeighbor(Neighbor.Left, previous);
 
@@ -79,27 +81,30 @@ namespace MenuChanger.NavigationTypes
 
         public override void ResetNavigation()
         {
-            if (Selectables.Count == 0)
+            if (selectables.Count == 0)
             {
                 Page.backButton.SetNeighbor(Neighbor.Up, null);
                 Page.backButton.SetNeighbor(Neighbor.Down, null);
             }
             else
             {
-                foreach (ISelectable selectable in Selectables)
+                foreach (ISelectable selectable in selectables)
                 {
-                    if (selectable is ISelectableGroup isg) isg.ResetNavigation();
+                    if (selectable is ISelectableGroup isg)
+                    {
+                        isg.ResetNavigation();
+                    }
                 }
 
-                for (int i = 0; i < Selectables.Count; i++)
+                for (int i = 0; i < selectables.Count; i++)
                 {
-                    int j = i > 0 ? i - 1 : Selectables.Count - 1;
-                    Selectables[i].SymSetNeighbor(Neighbor.Left, Selectables[j]);
-                    Selectables[i].SetNeighbor(Neighbor.Up, Page.backButton);
-                    Selectables[i].SetNeighbor(Neighbor.Down, Page.backButton);
+                    int j = i > 0 ? i - 1 : selectables.Count - 1;
+                    selectables[i].SymSetNeighbor(Neighbor.Left, selectables[j]);
+                    selectables[i].SetNeighbor(Neighbor.Up, Page.backButton);
+                    selectables[i].SetNeighbor(Neighbor.Down, Page.backButton);
                 }
-                Page.backButton.SetNeighbor(Neighbor.Up, Selectables[0]);
-                Page.backButton.SetNeighbor(Neighbor.Down, Selectables[0]);
+                Page.backButton.SetNeighbor(Neighbor.Up, selectables[0]);
+                Page.backButton.SetNeighbor(Neighbor.Down, selectables[0]);
             }
         }
 

--- a/MenuChanger/NavigationTypes/SimpleHorizontalNavigation.cs
+++ b/MenuChanger/NavigationTypes/SimpleHorizontalNavigation.cs
@@ -4,9 +4,13 @@ namespace MenuChanger.NavigationTypes
 {
     public class SimpleHorizontalNavigation : MenuPageNavigation
     {
-        public List<ISelectable> selectables = new();
+        /// <summary>
+        /// A list of selectables. Note: Prefer to use <see cref="Items"/> and the add/remove methods instead
+        /// of modifying this list directly
+        /// </summary>
+        public List<ISelectable> Selectables = new();
 
-        public override IReadOnlyCollection<ISelectable> Selectables => selectables.AsReadOnly();
+        public override IReadOnlyCollection<ISelectable> Items => Selectables.AsReadOnly();
 
         public SimpleHorizontalNavigation(MenuPage page) : base(page)
         {
@@ -14,9 +18,9 @@ namespace MenuChanger.NavigationTypes
 
         public override void SelectDefault()
         {
-            if (selectables.Count > 0)
+            if (Selectables.Count > 0)
             {
-                Selectable s = selectables[0].GetSelectable(Neighbor.Up);
+                Selectable s = Selectables[0].GetSelectable(Neighbor.Up);
                 if (s)
                 {
                     s.Select();
@@ -34,12 +38,12 @@ namespace MenuChanger.NavigationTypes
         {
             selectable.SetNeighbor(Neighbor.Down, Page.backButton);
             selectable.SetNeighbor(Neighbor.Up, Page.backButton);
-            if (selectables.Any())
+            if (Selectables.Any())
             {
-                selectable.SetNeighbor(Neighbor.Left, selectables[selectables.Count - 1]);
-                selectables[selectables.Count - 1].SetNeighbor(Neighbor.Right, selectable);
-                selectable.SetNeighbor(Neighbor.Right, selectables[0]);
-                selectables[0].SetNeighbor(Neighbor.Left, selectable);
+                selectable.SetNeighbor(Neighbor.Left, Selectables[Selectables.Count - 1]);
+                Selectables[Selectables.Count - 1].SetNeighbor(Neighbor.Right, selectable);
+                selectable.SetNeighbor(Neighbor.Right, Selectables[0]);
+                Selectables[0].SetNeighbor(Neighbor.Left, selectable);
             }
             else
             {
@@ -49,19 +53,19 @@ namespace MenuChanger.NavigationTypes
                 selectable.SetNeighbor(Neighbor.Right, selectable);
             }
 
-            selectables.Add(selectable);
+            Selectables.Add(selectable);
         }
 
         public override void Remove(ISelectable selectable)
         {
-            int i = selectables.IndexOf(selectable);
+            int i = Selectables.IndexOf(selectable);
             if (i >= 0)
             {
-                selectables.RemoveAt(i);
-                if (selectables.Any())
+                Selectables.RemoveAt(i);
+                if (Selectables.Any())
                 {
-                    ISelectable previous = selectables[i > 0 ? i - 1 : selectables.Count - 1];
-                    ISelectable next = selectables[i < selectables.Count ? i : 0];
+                    ISelectable previous = Selectables[i > 0 ? i - 1 : Selectables.Count - 1];
+                    ISelectable next = Selectables[i < Selectables.Count ? i : 0];
                     previous.SetNeighbor(Neighbor.Right, next);
                     next.SetNeighbor(Neighbor.Left, previous);
 
@@ -81,14 +85,14 @@ namespace MenuChanger.NavigationTypes
 
         public override void ResetNavigation()
         {
-            if (selectables.Count == 0)
+            if (Selectables.Count == 0)
             {
                 Page.backButton.SetNeighbor(Neighbor.Up, null);
                 Page.backButton.SetNeighbor(Neighbor.Down, null);
             }
             else
             {
-                foreach (ISelectable selectable in selectables)
+                foreach (ISelectable selectable in Selectables)
                 {
                     if (selectable is ISelectableGroup isg)
                     {
@@ -96,15 +100,15 @@ namespace MenuChanger.NavigationTypes
                     }
                 }
 
-                for (int i = 0; i < selectables.Count; i++)
+                for (int i = 0; i < Selectables.Count; i++)
                 {
-                    int j = i > 0 ? i - 1 : selectables.Count - 1;
-                    selectables[i].SymSetNeighbor(Neighbor.Left, selectables[j]);
-                    selectables[i].SetNeighbor(Neighbor.Up, Page.backButton);
-                    selectables[i].SetNeighbor(Neighbor.Down, Page.backButton);
+                    int j = i > 0 ? i - 1 : Selectables.Count - 1;
+                    Selectables[i].SymSetNeighbor(Neighbor.Left, Selectables[j]);
+                    Selectables[i].SetNeighbor(Neighbor.Up, Page.backButton);
+                    Selectables[i].SetNeighbor(Neighbor.Down, Page.backButton);
                 }
-                Page.backButton.SetNeighbor(Neighbor.Up, selectables[0]);
-                Page.backButton.SetNeighbor(Neighbor.Down, selectables[0]);
+                Page.backButton.SetNeighbor(Neighbor.Up, Selectables[0]);
+                Page.backButton.SetNeighbor(Neighbor.Down, Selectables[0]);
             }
         }
 

--- a/MenuChanger/NavigationTypes/SimpleHorizontalNavigation.cs
+++ b/MenuChanger/NavigationTypes/SimpleHorizontalNavigation.cs
@@ -1,4 +1,7 @@
 ﻿using MenuChanger.Extensions;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.UI;
 
 namespace MenuChanger.NavigationTypes
 {
@@ -28,10 +31,7 @@ namespace MenuChanger.NavigationTypes
                 }
             }
 
-            if (Page.backButton != null && Page.backButton.Button)
-            {
-                Page.backButton.Button.Select();
-            }
+            if (Page.backButton != null && Page.backButton.Button) Page.backButton.Button.Select();
         }
 
         public override void Add(ISelectable selectable)
@@ -94,10 +94,7 @@ namespace MenuChanger.NavigationTypes
             {
                 foreach (ISelectable selectable in Selectables)
                 {
-                    if (selectable is ISelectableGroup isg)
-                    {
-                        isg.ResetNavigation();
-                    }
+                    if (selectable is ISelectableGroup isg) isg.ResetNavigation();
                 }
 
                 for (int i = 0; i < Selectables.Count; i++)


### PR DESCRIPTION
* Expose selectables as a property of `MenuPageNavigation`
* Make `MenuPage.nav` field writeable
* Implement `MenuPage.ReplaceNavigation` method to move all existing controlled elements to a new navigation style
* Set up local overrides for easier local builds when forking/collaboration